### PR TITLE
Added correct function to create query AddImage file

### DIFF
--- a/src/components/AddPost/AddImage.tsx
+++ b/src/components/AddPost/AddImage.tsx
@@ -51,9 +51,9 @@ const AddPostImage: VFC<AddPostImageProps> = ({ onAddImage }) => {
         };
 
         const data = new FormData();
-        data.append('file', fileObject);
+        data.append('files', fileObject);
 
-        runQuery(createQuery(createFile, data, onProgress), ({ data: fileData, error }) => {
+        runQuery(createQuery(createImage, data, onProgress), ({ data: fileData, error }) => {
           onProgress(0);
 
           if (fileData) {


### PR DESCRIPTION
The `createfile` call returns the post type of file, which paired with the other code, creates an error with a mismatched post type. This should be changed to `createimage` call. Additionally, the SDK is looking for the header name of `files` not `file`.

Im sorry if it is not following the correct format, I didn't see any guidelines for that. This